### PR TITLE
fix: Use full URL when standardizing state

### DIFF
--- a/src/lib/SkHistoryApi.svelte.test.ts
+++ b/src/lib/SkHistoryApi.svelte.test.ts
@@ -47,14 +47,14 @@ const hoistedVars = vi.hoisted(() => ({
 
 vi.mock(import("$app/state"), async (importOriginal) => {
     return {
-        ...importOriginal,
+        ...await importOriginal(),
         page: {
             get url() {
-                return hoistedVars.urlMock();
+                return hoistedVars.urlMock() ?? new URL("http://localhost/");
             },
             get state() {
                 return hoistedVars.stateMock();
-            }
+            },
         } as Page
     }
 });

--- a/src/lib/SkHistoryApi.ts
+++ b/src/lib/SkHistoryApi.ts
@@ -15,7 +15,7 @@ export class SkHistoryApi implements HistoryApi {
         if (browser && !isConformantState(page.state)) {
             // I tried with replaceState() here, throws with error "cannot use before router initializes".
             // So, using goto() with replaceState: true.  This triggers an update on page.url, though.
-            goto('', { replaceState: true, state: { path: page.state, hash: {} } });
+            goto(page.url.toString(), { replaceState: true, state: { path: page.state, hash: {} } });
         }
     }
 


### PR DESCRIPTION
`SkHistoryApy`'s constructor was using shallow routing to standardize history state, but this was losing the URL's hash fragment on first loads.

Now a URL with a hash fragment can be pasted in the browser's location bar and will retain the hash fragment.